### PR TITLE
fix: send users roles in UserGetDto responses

### DIFF
--- a/TcgPocket/App/src/types/users.d.ts
+++ b/TcgPocket/App/src/types/users.d.ts
@@ -7,7 +7,10 @@ export type UserDto = {
   phoneNumber: string;
 };
 
-export type UserGetDto = Id & UserDto;
+export type UserGetDto = {
+  roles: List<RoleGetDto>;
+} & Id &
+  UserDto;
 
 export type UserCreateDto = UserDto & {
   password: string;

--- a/TcgPocket/Features/Users/Commands/SignInUserCommand.cs
+++ b/TcgPocket/Features/Users/Commands/SignInUserCommand.cs
@@ -33,6 +33,8 @@ public class SignInUserCommandHandler : IRequestHandler<SignInUserCommand, Respo
         
         var user = await _userManager
             .Users
+            .Include(x => x.UserRoles)
+            .ThenInclude(x => x.Role)
             .FirstOrDefaultAsync(x => x.NormalizedUserName == normalizedUserName, c);
         
         if (user is null) return Error.AsResponse<UserGetDto>("Username or password is incorrect");

--- a/TcgPocket/Features/Users/Commands/UpdatePasswordCommand.cs
+++ b/TcgPocket/Features/Users/Commands/UpdatePasswordCommand.cs
@@ -2,6 +2,7 @@
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using TcgPocket.Features.Users.Dtos;
 using TcgPocket.Shared;
 
@@ -35,7 +36,10 @@ public class UpdatePasswordCommandHandler : IRequestHandler<UpdatePasswordComman
             return new Response { Errors = errors };
         }
 
-        var user = _userManager.Users.FirstOrDefault(x => x.UserName == command.PasswordUpdateDto.UserName);
+        var user = _userManager.Users
+            .Include(x => x.UserRoles)
+            .ThenInclude(x => x.Role)
+            .FirstOrDefault(x => x.UserName == command.PasswordUpdateDto.UserName);
 
         if (user is null)
         {

--- a/TcgPocket/Features/Users/Commands/UpdateUserCommand.cs
+++ b/TcgPocket/Features/Users/Commands/UpdateUserCommand.cs
@@ -2,6 +2,7 @@
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using TcgPocket.Data;
 using TcgPocket.Shared;
 
@@ -41,7 +42,10 @@ public class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand, Respo
             return new Response<UserGetDto> { Errors = errors };
         }
 
-        var user = _userManager.Users.SingleOrDefault(x => x.Id == command.Id);
+        var user = _userManager.Users
+            .Include(x => x.UserRoles)
+            .ThenInclude(x => x.Role)
+            .SingleOrDefault(x => x.Id == command.Id);
 
         if (user is null)
         {

--- a/TcgPocket/Features/Users/Queries/GetAllUsersQuery.cs
+++ b/TcgPocket/Features/Users/Queries/GetAllUsersQuery.cs
@@ -25,7 +25,10 @@ public class GetAllUsersQueryHandler : IRequestHandler<GetAllUsersQuery, Respons
 
     public async Task<Response<List<UserGetDto>>> Handle(GetAllUsersQuery query, CancellationToken cancellationToken)
     {
-        var users = await _userManager.Users.ToListAsync(cancellationToken);
+        var users = await _userManager.Users
+            .Include(x => x.UserRoles)
+            .ThenInclude(x => x.Role)
+            .ToListAsync(cancellationToken);
 
         if (users.IsNullOrEmpty()) return Error.AsResponse<List<UserGetDto>>("Users not found");
 

--- a/TcgPocket/Features/Users/Queries/GetUserByIdQuery.cs
+++ b/TcgPocket/Features/Users/Queries/GetUserByIdQuery.cs
@@ -2,6 +2,7 @@
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using TcgPocket.Shared;
 
 namespace TcgPocket.Features.Users.Queries;
@@ -36,7 +37,10 @@ public class GetUserByIdQueryHandler : IRequestHandler<GetUserByIdQuery, Respons
             return new Response<UserGetDto> { Errors = errors };
         }
 
-        var user = _userManager.Users.SingleOrDefault(x => x.Id == query.Id);
+        var user = _userManager.Users
+            .Include(x => x.UserRoles)
+            .ThenInclude(x => x.Role)
+            .SingleOrDefault(x => x.Id == query.Id);
 
         if (user is null) return Error.AsResponse<UserGetDto>("User not found", "id");
 

--- a/TcgPocket/Features/Users/User.cs
+++ b/TcgPocket/Features/Users/User.cs
@@ -3,6 +3,7 @@ using TcgPocket.Features.Decks;
 using TcgPocket.Features.UserRoles;
 using TcgPocket.Features.UserCards;
 using TcgPocket.Shared.Interfaces;
+using TcgPocket.Features.Roles;
 
 namespace TcgPocket.Features.Users;
 
@@ -19,6 +20,7 @@ public class User : IdentityUser<int>, IIdentifiable
 public class UserGetDto : UserDto
 {
     public int Id { get; set; }
+    public List<RoleGetDto> Roles { get; set; }
 }
 
 public class UserDto

--- a/TcgPocket/Features/Users/UserMapper.cs
+++ b/TcgPocket/Features/Users/UserMapper.cs
@@ -7,7 +7,10 @@ public class UserMapper : Profile
 {
     public UserMapper()
     {
-        CreateMap<User, UserGetDto>();
+        CreateMap<User, UserGetDto>()
+            .ForMember(dest => dest.Roles, opts =>
+                opts.MapFrom(src => src.UserRoles.Select(x => x.Role)
+            ));
         CreateMap<User, UserDto>().ReverseMap();
 
         CreateMap<User, UserRoleDto>()


### PR DESCRIPTION
Allow user assigned roles to be seen on any request that returns a UserGetDto 